### PR TITLE
Resolves issue #7

### DIFF
--- a/src/Luhn.php
+++ b/src/Luhn.php
@@ -14,6 +14,8 @@
 
 namespace Selective\Luhn;
 
+use InvalidArgumentException;
+
 /**
  * Luhn.
  */
@@ -28,6 +30,8 @@ class Luhn
      */
     public function create(string $numbers): int
     {
+        $this->validateNumericString($numbers);
+
         // Add a zero check digit
         $numbers .= '0';
         $sum = 0;
@@ -54,6 +58,8 @@ class Luhn
      */
     public function validate(string $number): bool
     {
+        $this->validateNumericString($number);
+
         $sum = 0;
         $numDigits = strlen($number) - 1;
         $parity = $numDigits % 2;
@@ -68,5 +74,12 @@ class Luhn
         }
 
         return 0 == ($sum % 10);
+    }
+
+    private function validateNumericString(string $number): void
+    {
+        if (!preg_match('/^\d+$/', $number)) {
+            throw new InvalidArgumentException(sprintf('An invalid numeric value was given: %s', $number));
+        }
     }
 }

--- a/tests/LuhnTest.php
+++ b/tests/LuhnTest.php
@@ -4,6 +4,7 @@ namespace Selective\Luhn\Test;
 
 use Selective\Luhn\Luhn;
 use PHPUnit\Framework\TestCase;
+use InvalidArgumentException;
 
 class LuhnTest extends TestCase
 {
@@ -82,5 +83,27 @@ class LuhnTest extends TestCase
         $luhn = new Luhn();
 
         $this->assertSame($expected, $luhn->create($number));
+    }
+
+    public function testCreateOnInvalidNumericString(): void
+    {
+        $luhn = new Luhn();
+        $invalidNumericString = 'this_is_invalid_numeric_string';
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('An invalid numeric value was given: %s', $invalidNumericString));
+
+        $luhn->create($invalidNumericString);
+    }
+
+    public function testValidateOnInvalidNumericString(): void
+    {
+        $luhn = new Luhn();
+        $invalidNumericString = 'this_is_invalid_numeric_string';
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('An invalid numeric value was given: %s', $invalidNumericString));
+
+        $luhn->validate($invalidNumericString);
     }
 }


### PR DESCRIPTION
# Changed log
- It's related to issue #7.
- Implement the private `validateNumericString` method to ensure that passed numeric string is valid before doing `Luhn` algorithm calculation.